### PR TITLE
rate-text-color

### DIFF
--- a/shikimori_dark.css
+++ b/shikimori_dark.css
@@ -193,6 +193,7 @@ header.head .notice,
 }
 
 .p-user_rates-index .list-lines tr td .episodes_total,
+.p-user_rates-index .list-lines tr td .rate-text,
 .b-subposter-action,
 .l-top_menu-v2 .global-search .clear,
 .l-top_menu-v2 .global-search,


### PR DESCRIPTION
цвет описания
Было:
![image](https://github.com/user-attachments/assets/76f66f3b-fbf7-4f1c-bd6a-f45ec72d69a8)

Стало:
![image](https://github.com/user-attachments/assets/3b2f17a9-6277-4bb8-be7e-2f92d1ec58ad)

Но есть нюанс, на экранах меньше 1023px все равно тускло. я у себя решил добавив (ты мб иначе сделаешь):
https://github.com/media screen and (max-width: 1023px) {
.p-user_rates-index .list-lines tr td .rate-text {
color: var(--txt-secondary-dark);
}
}